### PR TITLE
interface properties containing dots should also be escaped

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -595,7 +595,7 @@ function escapeString(s: string): string {
 }
 
 function isValidPropertyKey(s: string): boolean {
-  return /[-\/\s]/.exec(s) === null
+  return /[-\/\s\.]/.exec(s) === null
 }
 
 function addRuntimeName(s: string, name?: string): string {

--- a/test/printRuntime.ts
+++ b/test/printRuntime.ts
@@ -153,13 +153,18 @@ describe('printRuntime', () => {
   it('escape property', () => {
     const declaration = t.typeDeclaration(
       'Foo',
-      t.interfaceCombinator([t.property('foo bar', t.stringType), t.property('image/jpeg', t.stringType)])
+      t.interfaceCombinator([
+        t.property('foo bar', t.stringType),
+        t.property('image/jpeg', t.stringType),
+        t.property('autoexec.bat', t.stringType)
+      ])
     )
     assert.strictEqual(
       t.printRuntime(declaration),
       `const Foo = t.interface({
   'foo bar': t.string,
-  'image/jpeg': t.string
+  'image/jpeg': t.string,
+  'autoexec.bat': t.string
 })`
     )
   })


### PR DESCRIPTION
...otherwise your output cannot be compiled.