### PR TITLE
fix readme backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ console.log(gen.printRuntime(declaration) + '\n')
 
 Output (as string)
 
-````ts
+```ts
 interface Person {
   name: string,
   age: number
@@ -157,4 +157,4 @@ t.interface({
   foo: t.string
 })
 */
-````
+```


### PR DESCRIPTION
there were four backticks instead of three in a couple of places and the formatting wasn't right.