### PR TITLE
update optional property support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -647,8 +647,23 @@ function printRuntimeProperty(p: Property, i: number): string {
 }
 
 function printRuntimeInterfaceCombinator(interfaceCombinator: InterfaceCombinator, i: number): string {
+  let requiredProperties: Property[] = []
+  let optionalProperties: Property[] = []
+  interfaceCombinator.properties.forEach(p => p.isOptional ? optionalProperties.push(p) : requiredProperties.push(p))
+  
+  if (requiredProperties.length > 0 && optionalProperties.length > 0) {
+    return printRuntimeIntersectionCombinator(intersectionCombinator([
+      exports.interfaceCombinator(requiredProperties),
+      partialCombinator(optionalProperties),
+    ]), i)
+  }
+  
+  if (optionalProperties.length > 0) {
+    return printRuntimePartialCombinator(partialCombinator(optionalProperties), i)
+  }
+  
   let s = 't.interface({\n'
-  s += interfaceCombinator.properties.map(p => printRuntimeProperty(p, i + 1)).join(',\n')
+  s += interfaceCombinator.properties.map(p => printRuntimeProperty({ ...p, isOptional: false }, i + 1)).join(',\n')
   s += `\n${indent(i)}}`
   s = addRuntimeName(s, interfaceCombinator.name)
   s += ')'

--- a/src/index.ts
+++ b/src/index.ts
@@ -649,21 +649,21 @@ function printRuntimeProperty(p: Property, i: number): string {
 function printRuntimeInterfaceCombinator(interfaceCombinator: InterfaceCombinator, i: number): string {
   let requiredProperties: Property[] = []
   let optionalProperties: Property[] = []
-  interfaceCombinator.properties.forEach(p => p.isOptional ? optionalProperties.push(p) : requiredProperties.push(p))
-  
+  interfaceCombinator.properties.forEach(p => (p.isOptional ? optionalProperties.push(p) : requiredProperties.push(p)))
+
   if (requiredProperties.length > 0 && optionalProperties.length > 0) {
-    return printRuntimeIntersectionCombinator(intersectionCombinator([
-      exports.interfaceCombinator(requiredProperties),
-      partialCombinator(optionalProperties),
-    ]), i)
+    return printRuntimeIntersectionCombinator(
+      intersectionCombinator([exports.interfaceCombinator(requiredProperties), partialCombinator(optionalProperties)]),
+      i
+    )
   }
-  
+
   if (optionalProperties.length > 0) {
     return printRuntimePartialCombinator(partialCombinator(optionalProperties), i)
   }
-  
+
   let s = 't.interface({\n'
-  s += interfaceCombinator.properties.map(p => printRuntimeProperty({ ...p, isOptional: false }, i + 1)).join(',\n')
+  s += interfaceCombinator.properties.map(p => printRuntimeProperty(p, i + 1)).join(',\n')
   s += `\n${indent(i)}}`
   s = addRuntimeName(s, interfaceCombinator.name)
   s += ')'

--- a/test/printRuntime.ts
+++ b/test/printRuntime.ts
@@ -57,13 +57,14 @@ describe('printRuntime', () => {
       )
       assert.strictEqual(
         t.printRuntime(declaration),
-        `const Foo = t.interface({
-  foo: t.string,
-  bar: t.union([
-    t.number,
-    t.undefined
-  ])
-})`
+        `const Foo = t.intersection([
+  t.interface({
+    foo: t.string
+  }),
+  t.partial({
+    bar: t.number
+  })
+])`
       )
     })
 
@@ -77,13 +78,17 @@ describe('printRuntime', () => {
       )
       assert.strictEqual(
         t.printRuntime(declaration),
-        `const Foo = t.interface({
-  foo: t.string,
-  bar: t.union([
-    t.number,
-    t.undefined
-  ])
-})`
+        `const Foo = t.intersection([
+  t.interface({
+    foo: t.string
+  }),
+  t.partial({
+    bar: t.union([
+      t.number,
+      t.undefined
+    ])
+  })
+])`
       )
     })
   })


### PR DESCRIPTION
@gcanti @giogonzo

For interfaces with optional properties, use either partialCombinator (for all optional) or intersectionCombinator (for mixed) to allow for true optional properties, which don't require explicitly assigning undefined.

Addresses https://github.com/gcanti/io-ts-codegen/issues/26.
This can likely be simplified or reverted if a solution for https://github.com/gcanti/io-ts/issues/140 is found.