### PR TITLE
Interface properties containing square bracket should also be escaped

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -595,7 +595,7 @@ function escapeString(s: string): string {
 }
 
 function isValidPropertyKey(s: string): boolean {
-  return /[-\/\s\.]/.exec(s) === null
+  return /[-\/\s\.\[\]]/.exec(s) === null
 }
 
 function addRuntimeName(s: string, name?: string): string {

--- a/test/printStatic.ts
+++ b/test/printStatic.ts
@@ -95,13 +95,18 @@ describe('printStatic', () => {
     it('should escape properties', () => {
       const declaration = t.typeDeclaration(
         'Foo',
-        t.interfaceCombinator([t.property('foo bar', t.stringType), t.property('image/jpeg', t.stringType)])
+        t.interfaceCombinator([
+          t.property('foo bar', t.stringType),
+          t.property('image/jpeg', t.stringType),
+          t.property('foo[bar]', t.stringType)
+        ])
       )
       assert.strictEqual(
         t.printStatic(declaration),
         `interface Foo {
   'foo bar': string,
-  'image/jpeg': string
+  'image/jpeg': string,
+  'foo[bar]': string
 }`
       )
     })


### PR DESCRIPTION
Hi, 

I've added properties like this: `foo[bar]` should be escaped. 

Thanks a lot,

Have a good day