### PR TITLE
Bug Fix: the static type outputted by dictionaries should use `in`instead of `:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.2.2
+
+* **Bug Fix**
+  * the static type outputted by dictionaries should use `in` (@gcanti)
+
 # 0.2.1
 
 * **Bug Fix**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-codegen",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Code generation for io-ts",
   "files": ["lib"],
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -930,7 +930,7 @@ function printStaticReadonlyArrayCombinator(c: ReadonlyArrayCombinator, i: numbe
 }
 
 function printStaticDictionaryCombinator(c: DictionaryCombinator, i: number): string {
-  return `{ [key: ${printStatic(c.domain, i)}]: ${printStatic(c.codomain, i)} }`
+  return `{ [key in ${printStatic(c.domain, i)}]: ${printStatic(c.codomain, i)} }`
 }
 
 function printStaticTupleCombinator(c: TupleCombinator, i: number): string {

--- a/test/printStatic.ts
+++ b/test/printStatic.ts
@@ -156,7 +156,7 @@ describe('printStatic', () => {
 
   it('dictionary', () => {
     const declaration = t.typeDeclaration('Foo', t.dictionaryCombinator(t.stringType, t.numberType))
-    assert.strictEqual(t.printStatic(declaration), `type Foo = { [key: string]: number }`)
+    assert.strictEqual(t.printStatic(declaration), `type Foo = { [key in string]: number }`)
   })
 
   it('readonly interface', () => {

--- a/test/sort.ts
+++ b/test/sort.ts
@@ -143,7 +143,7 @@ export const Persons = t.array(Person)`
       `export interface NotificationPayload {
   userLanguage?: string,
   notificationKind: NotificationKind,
-  params: { [key: string]: any },
+  params: { [key in string]: any },
   workcellSerialNumber: string,
   workcellType: InstrumentType
 }`


### PR DESCRIPTION
Reference: https://github.com/buildo/metarpheus-io-ts/pull/63