### PR TITLE
New feature: overload `t.property` function

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -831,12 +831,8 @@ export function printStatic(node: Node, i: number = 0): string { ... }
 **Signature**
 
 ```ts
-export function property(
-  key: string,
-  type: TypeReference,
-  isOptional: boolean = false,
-  description?: string
-): Property { ... }
+export function property(key: string, type: TypeReference, description?: string): Property
+export function property(key: string, type: TypeReference, isOptional?: boolean, description?: string): Property { ... }
 ```
 
 # readonlyArrayCombinator (function)

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,12 +301,23 @@ export function identifier(name: string): Identifier {
   }
 }
 
+export function property(key: string, type: TypeReference, description?: string): Property
+export function property(key: string, type: TypeReference, isOptional?: boolean, description?: string): Property
 export function property(
   key: string,
   type: TypeReference,
-  isOptional: boolean = false,
+  isOptional: boolean | string = false,
   description?: string
 ): Property {
+  if (typeof isOptional === 'string') {
+    return {
+      kind: 'Property',
+      key,
+      type,
+      isOptional: false,
+      description: isOptional // actually description from the overloaded signature
+    }
+  }
   return {
     kind: 'Property',
     key,

--- a/test/property.ts
+++ b/test/property.ts
@@ -1,0 +1,18 @@
+import * as assert from 'assert'
+import * as t from '../src'
+
+describe('property overload', () => {
+  it('should be the same without description', () => {
+    const longForm = t.typeCombinator([t.property('foo', t.stringType, false)])
+    const shortForm = t.typeCombinator([t.property('foo', t.stringType)])
+
+    assert.deepEqual(shortForm, longForm)
+  })
+
+  it('should be the same with description', () => {
+    const longForm = t.typeCombinator([t.property('foo', t.stringType, false, 'test')])
+    const shortForm = t.typeCombinator([t.property('foo', t.stringType, 'test')])
+
+    assert.deepEqual(shortForm, longForm)
+  })
+})


### PR DESCRIPTION
I have lots of properties in my code, all of them are required but with supplied description. It would be really nice to be able to supply property function with description without supplying `isOptional` property.