### PR TITLE
Fix properties starting with digit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -641,7 +641,7 @@ function escapeString(s: string): string {
 }
 
 function isValidPropertyKey(s: string): boolean {
-  return /\W/.exec(s) === null
+  return /(^\d|\W)/.exec(s) === null
 }
 
 function addRuntimeName(s: string, name?: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -641,7 +641,7 @@ function escapeString(s: string): string {
 }
 
 function isValidPropertyKey(s: string): boolean {
-  return /(^\d|\W)/.exec(s) === null
+  return !/(^\d|\W)/.test(s)
 }
 
 function addRuntimeName(s: string, name?: string): string {

--- a/test/printRuntime.ts
+++ b/test/printRuntime.ts
@@ -29,6 +29,17 @@ describe('printRuntime', () => {
     )
   })
 
+  it('keyofCombinator stating with digit', () => {
+    const declaration = t.typeDeclaration('Foo', t.keyofCombinator(['01test', '1']))
+    assert.strictEqual(
+      t.printRuntime(declaration),
+      `const Foo = t.keyof({
+  '01test': null,
+  '1': null
+})`
+    )
+  })
+
   it('tupleCombinator', () => {
     const declaration = t.typeDeclaration('Foo', t.tupleCombinator([t.stringType, t.numberType]))
     assert.strictEqual(


### PR DESCRIPTION
Hello ! 

Thanks a lot for your ts libraries. I use them on several projects and they are very useful.

I noticed that a key such as `123abc` was not properly quoted by io-ts-codegen. 

This PR : 
 - Adds a test for this case
 - Changes the quoting behavior to also quote every property starting with a digit
 - Uses `test` instead of exec in the regex use by `isValidPropertyKey` (I could not find a good reason not to use that as it seems more straightforward and potentially more performant)

Technically, numbers like `1235` do not need to be quoted as they are coerced to string but it seems reasonable to me to keep a simpler regex.

There is are however a few cases when quoting will change the behavior. If your key is a number in octal or hexa : for instance, the litteral `{ 01234: null }` is in fact`{'668': null}`. But then again, I guess this would also be considered as a bug in io-ts-codegen so it seems ok 😄.