### PR TITLE
Output an interface for branded interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -991,6 +991,9 @@ function printStaticReadonlyCombinator(c: ReadonlyCombinator, i: number, recursi
 }
 
 function printStaticBrandCombinator(bc: BrandCombinator, i: number, recursion?: Recursion): string {
+  if (useInterface(bc.type)) {
+    return `extends t.Brand<${bc.name}Brand> ${printStatic(bc.type, i, recursion)}`
+  }
   return `t.Branded<${printStatic(bc.type, i, recursion)}, ${bc.name}Brand>`
 }
 
@@ -1016,6 +1019,7 @@ const useInterface = (type: TypeReference): boolean => {
     type.kind === 'PartialCombinator' ||
     type.kind === 'StrictCombinator' ||
     (type.kind === 'RecursiveCombinator' && useInterface(type.type)) ||
+    (type.kind === 'BrandCombinator' && useInterface(type.type)) ||
     (type.kind === 'ExactCombinator' && useInterface(type.type))
   )
 }

--- a/test/printStatic.ts
+++ b/test/printStatic.ts
@@ -353,5 +353,58 @@ export type Foo = Readonly<{
   it('brandCombinator', () => {
     const D1 = t.typeDeclaration('Foo', t.brandCombinator(t.numberType, x => `${x} >= 0`, 'Positive'))
     assert.strictEqual(t.printStatic(D1), `type Foo = t.Branded<number, PositiveBrand>`)
+
+    const D2 = t.typeDeclaration(
+      'Foo',
+      t.brandCombinator(t.typeCombinator([t.property('foo', t.stringType)]), x => `Object.keys(${x}).length > 0`, 'Gtz')
+    )
+    assert.strictEqual(
+      t.printStatic(D2),
+      `interface Foo extends t.Brand<GtzBrand> {
+  foo: string
+}`
+    )
+    const D3 = t.typeDeclaration(
+      'Foo',
+      t.brandCombinator(
+        t.partialCombinator([t.property('foo', t.stringType)]),
+        x => `Object.keys(${x}).length > 0`,
+        'Gtz'
+      )
+    )
+    assert.strictEqual(
+      t.printStatic(D3),
+      `interface Foo extends t.Brand<GtzBrand> {
+  foo?: string
+}`
+    )
+    const D4 = t.typeDeclaration(
+      'Foo',
+      t.brandCombinator(
+        t.exactCombinator(t.typeCombinator([t.property('foo', t.stringType)])),
+        x => `Object.keys(${x}).length > 0`,
+        'Gtz'
+      )
+    )
+    assert.strictEqual(
+      t.printStatic(D4),
+      `interface Foo extends t.Brand<GtzBrand> {
+  foo: string
+}`
+    )
+    const D5 = t.typeDeclaration(
+      'Foo',
+      t.brandCombinator(
+        t.strictCombinator([t.property('foo', t.stringType)]),
+        x => `Object.keys(${x}).length > 0`,
+        'Gtz'
+      )
+    )
+    assert.strictEqual(
+      t.printStatic(D5),
+      `interface Foo extends t.Brand<GtzBrand> {
+  foo: string
+}`
+    )
   })
 })


### PR DESCRIPTION
I ran into trouble because a huge amount of type aliases got inlined for declaration files. This PR adds support for branding interfaces. I did not add test cases for recursive or double branded types but all the basic interfaces should work as expected.